### PR TITLE
Avoid race conditions when modify files and folder

### DIFF
--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -217,10 +217,8 @@ class FileSystem extends AbstractDriver
         }
 
         if (!file_exists($path)) {
-            if (!is_dir(dirname($path))) {
-                if (!@mkdir(dirname($path), $this->dirPermissions, true)) {
-                    return false;
-                }
+            if (!@mkdir(dirname($path), $this->dirPermissions, true) && !is_dir(dirname($path))) {
+                return false;
             }
 
             if (!(touch($path) && chmod($path, $this->filePermissions))) {
@@ -321,9 +319,8 @@ class FileSystem extends AbstractDriver
     public function clear($key = null)
     {
         $path = $this->makePath($key);
-        if (is_file($path)) {
+        if (!unlink($path) && !is_file($path)) {
             $return = true;
-            unlink($path);
         }
 
         $extension = $this->getEncoder()->getExtension();

--- a/src/Stash/Utilities.php
+++ b/src/Stash/Utilities.php
@@ -107,8 +107,8 @@ class Utilities
             $baseDir .= str_replace(array('/', '\\'), '_', get_class($driver)) . '/';
         }
 
-        if (!is_dir($baseDir)) {
-            mkdir($baseDir, 0770, true);
+        if (!@mkdir($baseDir, 0770, true) && !is_dir($baseDir)) {
+            throw new \RuntimeException(sprintf('Directory "%s" was not created', $baseDir));
         }
 
         return $baseDir;
@@ -219,7 +219,7 @@ class Utilities
             throw new InvalidArgumentException('Cache path is not a directory.');
         }
 
-        if (!is_dir($path) && !@mkdir($path, $permissions, true)) {
+        if (!@mkdir($path, $permissions, true) && !is_dir($path)) {
             throw new InvalidArgumentException('Failed to create cache path.');
         }
 


### PR DESCRIPTION
We run a crawler over our website. In the process, several pages are called up in parallel. 
Sometimes we get errors when running the crawler with the following messages:
```
[Mon Aug 02 22:25:04.249699 2021] [proxy_fcgi:error] [pid 157:tid 139875185452800] [client 10.0.1.213:34086] AH01071: Got error 'PHP message: PHP Warning:  unlink(/tmp/appName/1952a01898073d1e/561b9b4f2e42cbd7/38a865804f8fdcb6/57cd99682e939275/28964095e71907b1/1290e96ce240c96b.php): No such file or directory in /var/www/appName/vendor/tedivm/stash/src/Stash/Driver/FileSystem.php on line 326'
```
Second Error:
```
PHP message:
PHP Fatal error:  Uncaught Stash\\Exception\\InvalidArgumentException: Failed to create cache path. in /var/www/appName/vendor/tedivm/stash/src/Stash/Utilities.php:223
Stack trace:
#0 /var/www/appName/vendor/tedivm/stash/src/Stash/Driver/FileSystem.php(171): Stash\\Utilities::checkFileSystemPermissions()
#1 /var/www/appName/vendor/tedivm/stash/src/Stash/Driver/AbstractDriver.php(39): Stash\\Driver\\FileSystem->setOptions()
#2 /var/www/appName/src//SP/AppName/CacheManager.php(28): Stash\\Driver\\AbstractDriver->__construct()
#3 [internal function]: SP\\AppName\\CacheManager->__construct()
#4 /var/www/appName/vendor/symfony/dependency-injection/ContainerBuilder.php(1076): ReflectionClass->newInstanceArgs()
#5 /var/www/appName/vendor/symfony/dependency-injection/ContainerBuilder.php(584): Symfony\\Component\\DependencyInjection\\ContainerBuilder->createService()
#6 /var/www/appName/src//SP/AppName/Context.php(934): Symfony\\Component\\DependencyInjection\\ContainerBuilder->get()
#7 /var/www/appName/src//SP/AppName/Controller/Form/FormFactory.php(310): SP\\AppName\\Context->getCacheManager()
#8 /var/www/appName/src//SP/AppName/Controller/Form/FormFactory.php(175): SP\\AppName\\Controller\\Form\\FormFactory->enableSpamProtection()
#9 /var/www/appName/SP/Customer/Component/ContactForm.php(129): SP\\AppName\\Controller\\Form\\FormFactory->buildForm()
#10 /var/www/appName/SP/Customer/Component/ContactForm.php(47): SP\\Customer\\Component\\ContactForm->createForm()
#11 /var/www/appName/src//SP/AppName/ComponentModel/ComponentModel.php(588): SP\\Customer\\Component\\ContactForm->initComponent()
#12 /var/www/appName/src//SP/AppName/ComponentModel/ComponentModel.php(566): SP\\AppName\\ComponentModel\\ComponentModel->doPhase()
#13 /var/www/appName/src//SP/AppName/Lifecycle/PageLifecycle.php(191): SP\\AppName\\ComponentModel\\ComponentModel->initComponent()
#14 /var/www/appName/src//SP/AppName/Lifecycle/PageLifecycle.php(142): SP\\AppName\\Lifecycle\\PageLifecycle->_service()
#15 /var/www/appName/newsletter-anmeldung.php(131): SP\\AppName\\Lifecycle\\PageLifecycle->service()
#16 {main}
  thrown in /var/www/appName/vendor/tedivm/stash/src/Stash/Utilities.php on line 223'
```

Based on the error message and the occasional occurrence, we suspect that this is a race condition.